### PR TITLE
Add PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+# Trusted Publisher setup (one-time, manual):
+# 1. Go to https://pypi.org/manage/account/publishing/
+# 2. Add a new pending publisher:
+#    - Owner: martinmiglio
+#    - Repository: brasa
+#    - Workflow: publish.yml
+#    - Environment: pypi
+
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # Required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Triggers on `v*` tag push
- Uses trusted publisher (OIDC) — no API tokens needed
- `uv build` produces sdist + wheel, `pypa/gh-action-pypi-publish` uploads
- Includes one-time trusted publisher setup instructions in comments

Closes #7

## Test plan
- [x] YAML is well-formed
- [ ] Set up trusted publisher on PyPI (manual, one-time)
- [ ] Test with a `v0.1.0` tag after CI is merged