### PR TITLE
Add Makefile for common dev tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,12 @@ uv run pytest                  # run tests
 uv run ruff check src/         # lint
 uv run ruff format src/        # format
 uv run ty check src/           # type check
+
+# Or use Make targets:
+make check                     # lint + typecheck + test
+make lint / make format        # ruff
+make typecheck                 # ty
+make test / make test-cov      # pytest
 ```
 
 ## Code style

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: install lint format typecheck test test-cov check
+
+install:
+	uv sync
+
+lint:
+	uv run ruff check src/
+
+format:
+	uv run ruff format src/
+
+typecheck:
+	uv run ty check src/
+
+test:
+	uv run pytest
+
+test-cov:
+	uv run pytest --cov=brasa
+
+check: lint typecheck test


### PR DESCRIPTION
## Summary
- Add `Makefile` with targets: `install`, `lint`, `format`, `typecheck`, `test`, `test-cov`, `check`
- `make check` runs lint + typecheck + test in one command
- Update `AGENTS.md` to document Make targets

Closes #25

## Test plan
- [x] `make check` runs lint, typecheck, and tests successfully
- [x] All targets use real tabs