### PR TITLE
Add GitHub Release with auto-generated notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,14 +13,25 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write # Required for creating releases
+  id-token: write # Required for trusted publishing
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: pypi
-    permissions:
-      id-token: write # Required for trusted publishing
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Add `release` job to publish workflow that runs after PyPI upload
- Uses `gh release create` with `--generate-notes` for automatic changelog
- Moved `permissions` to workflow level to cover both jobs

Closes #30

## Test plan
- [ ] Next `v*` tag push creates a GitHub Release with auto-generated notes