### PR TITLE
core/output: terminal output helpers

### DIFF
--- a/src/brasa/core/output.py
+++ b/src/brasa/core/output.py
@@ -1,0 +1,88 @@
+"""Terminal output helpers — colored, tagged printing to stderr/stdout."""
+
+import os
+import sys
+
+# ANSI escape codes
+_RESET = "\033[0m"
+_RED = "\033[31m"
+_YELLOW = "\033[33m"
+_GREEN = "\033[32m"
+_CYAN = "\033[36m"
+_DIM = "\033[2m"
+
+CYAN = _CYAN
+RED = _RED
+YELLOW = _YELLOW
+GREEN = _GREEN
+
+
+def _no_color() -> bool:
+    """Return True when ANSI codes should be suppressed (per https://no-color.org)."""
+    return "NO_COLOR" in os.environ
+
+
+def _wrap(text: str, code: str) -> str:
+    if _no_color():
+        return text
+    return f"{code}{text}{_RESET}"
+
+
+# ── Color helpers ────────────────────────────────────────────────────────────
+
+
+def red(text: str) -> str:
+    """Wrap *text* in red ANSI escape codes."""
+    return _wrap(text, _RED)
+
+
+def yellow(text: str) -> str:
+    """Wrap *text* in yellow ANSI escape codes."""
+    return _wrap(text, _YELLOW)
+
+
+def green(text: str) -> str:
+    """Wrap *text* in green ANSI escape codes."""
+    return _wrap(text, _GREEN)
+
+
+def cyan(text: str) -> str:
+    """Wrap *text* in cyan ANSI escape codes."""
+    return _wrap(text, _CYAN)
+
+
+def dim(text: str) -> str:
+    """Wrap *text* in dim ANSI escape codes."""
+    return _wrap(text, _DIM)
+
+
+# ── Tagged output ────────────────────────────────────────────────────────────
+
+
+def status(tag: str, msg: str, color: str = CYAN) -> None:
+    """Print ``[tag] msg`` to stderr with ANSI *color* on the tag."""
+    colored_tag = _wrap(f"[{tag}]", color)
+    print(f"{colored_tag} {msg}", file=sys.stderr)
+
+
+def error(msg: str) -> None:
+    """Print a red ``[error] msg`` to stderr."""
+    status("error", msg, color=RED)
+
+
+def warn(msg: str) -> None:
+    """Print a yellow ``[warning] msg`` to stderr."""
+    status("warning", msg, color=YELLOW)
+
+
+def success(msg: str) -> None:
+    """Print a green ``[ok] msg`` to stderr."""
+    status("ok", msg, color=GREEN)
+
+
+# ── Stdout helper ────────────────────────────────────────────────────────────
+
+
+def print_stdout(msg: str) -> None:
+    """Print *msg* to stdout with ``flush=True`` (for real-time serial output)."""
+    print(msg, file=sys.stdout, flush=True)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,128 @@
+"""Tests for brasa.core.output."""
+
+import os
+
+import pytest
+
+from brasa.core.output import (
+    cyan,
+    dim,
+    error,
+    green,
+    print_stdout,
+    red,
+    status,
+    success,
+    warn,
+    yellow,
+)
+
+# ── Color helpers ────────────────────────────────────────────────────────────
+
+
+def test_red_wraps_text() -> None:
+    assert red("hello") == "\033[31mhello\033[0m"
+
+
+def test_yellow_wraps_text() -> None:
+    assert yellow("hello") == "\033[33mhello\033[0m"
+
+
+def test_green_wraps_text() -> None:
+    assert green("hello") == "\033[32mhello\033[0m"
+
+
+def test_cyan_wraps_text() -> None:
+    assert cyan("hello") == "\033[36mhello\033[0m"
+
+
+def test_dim_wraps_text() -> None:
+    assert dim("hello") == "\033[2mhello\033[0m"
+
+
+# ── NO_COLOR ─────────────────────────────────────────────────────────────────
+
+
+def test_no_color_strips_ansi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert red("hello") == "hello"
+    assert green("hello") == "hello"
+    assert cyan("hello") == "hello"
+    assert dim("hello") == "hello"
+
+
+def test_no_color_affects_status(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    status("test", "message")
+    captured = capsys.readouterr()
+    assert captured.err == "[test] message\n"
+    assert "\033[" not in captured.err
+
+
+# ── status() ─────────────────────────────────────────────────────────────────
+
+
+def test_status_outputs_to_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+    old = os.environ.pop("NO_COLOR", None)
+    try:
+        status("deploy", "uploading files")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "[deploy]" in captured.err
+        assert "uploading files" in captured.err
+    finally:
+        if old is not None:
+            os.environ["NO_COLOR"] = old
+
+
+def test_status_uses_ansi_color(capsys: pytest.CaptureFixture[str]) -> None:
+    old = os.environ.pop("NO_COLOR", None)
+    try:
+        status("info", "hello", color="\033[31m")
+        captured = capsys.readouterr()
+        assert "\033[31m[info]\033[0m hello\n" == captured.err
+    finally:
+        if old is not None:
+            os.environ["NO_COLOR"] = old
+
+
+# ── error / warn / success ───────────────────────────────────────────────────
+
+
+def test_error_uses_red_tag(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    error("something broke")
+    captured = capsys.readouterr()
+    assert captured.err == "[error] something broke\n"
+
+
+def test_warn_uses_yellow_tag(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    warn("careful")
+    captured = capsys.readouterr()
+    assert captured.err == "[warning] careful\n"
+
+
+def test_success_uses_green_tag(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    success("done")
+    captured = capsys.readouterr()
+    assert captured.err == "[ok] done\n"
+
+
+# ── print_stdout ─────────────────────────────────────────────────────────────
+
+
+def test_print_stdout_outputs_to_stdout(capsys: pytest.CaptureFixture[str]) -> None:
+    print_stdout("serial data")
+    captured = capsys.readouterr()
+    assert captured.out == "serial data\n"
+    assert captured.err == ""


### PR DESCRIPTION
## Summary
- Add `core/output.py` with tagged print, ANSI color helpers, and `NO_COLOR` support
- Add unit tests in `tests/test_output.py`

Closes #9

## Test plan
- [x] `uv run pytest tests/test_output.py` passes (13 tests)
- [x] `uv run ruff check src/` passes