### PR TITLE
core/port: serial port detection

### DIFF
--- a/src/brasa/core/port.py
+++ b/src/brasa/core/port.py
@@ -1,0 +1,99 @@
+"""Serial port auto-detection with USB tree fallback for driver hints."""
+
+import glob
+import json
+import subprocess
+from collections.abc import Sequence
+
+from brasa.core import output
+
+DEFAULT_PATTERNS: list[str] = [
+    "/dev/cu.usbserial*",
+    "/dev/cu.wchusbserial*",
+    "/dev/cu.SLAB_USBtoUART*",
+]
+
+_KNOWN_VENDOR_IDS: dict[str, str] = {
+    "0x1a86": "CH340 (try: brew install ch34x-driver)",
+    "0x10c4": "CP2102 (try: brew install silabs-cp2102-driver)",
+}
+
+
+def detect_port(patterns: Sequence[str] | None = None) -> str:
+    """Detect a serial port by globbing *patterns*.
+
+    Returns the port path on success.  Calls :func:`_usb_tree_fallback` and
+    raises ``SystemExit(1)`` when no port is found.
+    """
+    if patterns is None:
+        patterns = DEFAULT_PATTERNS
+
+    matches: list[str] = []
+    for pattern in patterns:
+        matches.extend(glob.glob(pattern))
+
+    if len(matches) == 1:
+        return matches[0]
+
+    if len(matches) > 1:
+        output.warn(f"multiple serial ports found: {', '.join(matches)}")
+        return matches[0]
+
+    # No matches — run diagnostics then exit.
+    output.error("no serial port found")
+    _usb_tree_fallback()
+    raise SystemExit(1)
+
+
+def _usb_tree_fallback() -> None:
+    """Inspect the macOS USB tree for devices and suggest driver fixes."""
+    try:
+        result = subprocess.run(
+            ["system_profiler", "SPUSBDataType", "-json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        data = json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+        output.error("could not query USB devices — check connection and try again")
+        return
+
+    devices = _extract_usb_devices(data)
+    if not devices:
+        output.error("no USB devices detected — check your cable")
+        return
+
+    for device in devices:
+        vendor_id = device.get("vendor_id", "")
+        name = device.get("_name", "unknown device")
+        hint = _KNOWN_VENDOR_IDS.get(vendor_id)
+        if hint:
+            output.warn(f"found USB device '{name}' but no serial port — {hint}")
+            return
+
+    # USB devices present but no known vendor ID matched.
+    output.warn("USB device(s) detected but no matching serial driver found")
+
+
+def _extract_usb_devices(data: dict[str, object]) -> list[dict[str, object]]:
+    """Recursively pull USB device entries from system_profiler JSON."""
+    devices: list[dict[str, object]] = []
+    items: object = data.get("SPUSBDataType", [])
+    if isinstance(items, list):
+        _walk_items(items, devices)
+    return devices
+
+
+def _walk_items(
+    items: list[object], acc: list[dict[str, object]]
+) -> None:
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        # A device entry has a vendor_id key; hubs may just nest children.
+        if "vendor_id" in item:
+            acc.append(item)  # type: ignore[arg-type]
+        children: object = item.get("_items")
+        if isinstance(children, list):
+            _walk_items(children, acc)

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,0 +1,73 @@
+"""Tests for brasa.core.port — serial port detection."""
+
+import json
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from brasa.core.port import _usb_tree_fallback, detect_port
+
+# ── detect_port ─────────────────────────────────────────────────────────────
+
+
+def test_single_port_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("brasa.core.port.glob.glob", lambda p: ["/dev/cu.usbserial-1"] if "usbserial" in p else [])
+    assert detect_port() == "/dev/cu.usbserial-1"
+
+
+def test_multiple_ports_warns_and_returns_first(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    ports = ["/dev/cu.usbserial-1", "/dev/cu.usbserial-2"]
+    monkeypatch.setattr("brasa.core.port.glob.glob", lambda p: ports if "usbserial" in p else [])
+    result = detect_port()
+    assert result == "/dev/cu.usbserial-1"
+    err = capsys.readouterr().err
+    assert "multiple serial ports found" in err
+
+
+def test_no_ports_triggers_fallback_and_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("brasa.core.port.glob.glob", lambda _p: [])
+    monkeypatch.setattr("brasa.core.port._usb_tree_fallback", lambda: None)
+    with pytest.raises(SystemExit, match="1"):
+        detect_port()
+
+
+def test_custom_patterns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("brasa.core.port.glob.glob", lambda p: ["/dev/ttyUSB0"] if "ttyUSB" in p else [])
+    assert detect_port(patterns=["/dev/ttyUSB*"]) == "/dev/ttyUSB0"
+
+
+# ── _usb_tree_fallback ─────────────────────────────────────────────────────
+
+
+def _make_profiler_result(data: dict[str, object]) -> MagicMock:
+    mock = MagicMock(spec=subprocess.CompletedProcess)
+    mock.stdout = json.dumps(data)
+    return mock
+
+
+def test_fallback_known_vendor_suggests_driver(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    data = {"SPUSBDataType": [{"_name": "USB2.0-Ser!", "vendor_id": "0x1a86"}]}
+    monkeypatch.setattr("brasa.core.port.subprocess.run", lambda *a, **kw: _make_profiler_result(data))
+    _usb_tree_fallback()
+    err = capsys.readouterr().err
+    assert "CH340" in err
+    assert "brew install" in err
+
+
+def test_fallback_no_devices_suggests_cable(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    data: dict[str, object] = {"SPUSBDataType": []}
+    monkeypatch.setattr("brasa.core.port.subprocess.run", lambda *a, **kw: _make_profiler_result(data))
+    _usb_tree_fallback()
+    err = capsys.readouterr().err
+    assert "cable" in err
+
+
+def test_fallback_timeout_handled(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    def _raise_timeout(*_a: object, **_kw: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="system_profiler", timeout=10)
+
+    monkeypatch.setattr("brasa.core.port.subprocess.run", _raise_timeout)
+    _usb_tree_fallback()
+    err = capsys.readouterr().err
+    assert "could not query" in err


### PR DESCRIPTION
## Summary
- Add `core/port.py` with glob-based port scanning and USB tree fallback
- Map known vendor IDs to driver install suggestions
- Add unit tests in `tests/test_port.py`

Closes #10

## Test plan
- [x] `uv run pytest tests/test_port.py` passes
- [x] `uv run ruff check src/` passes