### PR TITLE
commands: detect, serial, repl, restart, exec

### DIFF
--- a/src/brasa/cli.py
+++ b/src/brasa/cli.py
@@ -17,11 +17,23 @@ def _version_callback(value: bool) -> None:
 
 @app.callback()
 def _main(
+    ctx: typer.Context,
     version: bool = typer.Option(
         False, "--version", "-V", callback=_version_callback, is_eager=True
     ),
+    port: str | None = typer.Option(
+        None, "--port", "-p", help="Serial port (auto-detected if omitted)"
+    ),
 ) -> None:
-    pass
+    ctx.ensure_object(dict)
+    ctx.obj["port"] = port
+
+
+# Register commands — imported after `app` is defined to avoid circular imports.
+from brasa.commands import detect, exec, repl, restart, serial  # noqa: E402, F811
+
+# Keep references so linters don't flag unused imports.
+__all__ = ["detect", "exec", "repl", "restart", "serial"]
 
 
 def main() -> None:

--- a/src/brasa/commands/detect.py
+++ b/src/brasa/commands/detect.py
@@ -1,0 +1,17 @@
+"""detect command — print the auto-detected (or overridden) serial port."""
+
+import typer
+
+from brasa.cli import app
+from brasa.core.output import print_stdout
+from brasa.core.port import detect_port
+
+
+@app.command()
+def detect(ctx: typer.Context) -> None:
+    """Detect the serial port of a connected MicroPython device."""
+    port = ctx.obj.get("port") if ctx.obj else None
+    if port:
+        print_stdout(port)
+    else:
+        print_stdout(detect_port())

--- a/src/brasa/commands/exec.py
+++ b/src/brasa/commands/exec.py
@@ -1,0 +1,22 @@
+"""exec command — execute a Python expression on the device."""
+
+import typer
+
+from brasa.cli import app
+from brasa.core.device import exec_expr
+from brasa.core.lock import port_lock
+from brasa.core.output import print_stdout
+from brasa.core.port import detect_port
+
+
+@app.command(name="exec")
+def exec_cmd(
+    ctx: typer.Context,
+    expression: str = typer.Argument(help="Python expression to execute on device"),
+) -> None:
+    """Execute a Python expression on the device."""
+    port = (ctx.obj.get("port") if ctx.obj else None) or detect_port()
+    with port_lock(port, "exec"):
+        result = exec_expr(port, expression)
+        if result:
+            print_stdout(result)

--- a/src/brasa/commands/repl.py
+++ b/src/brasa/commands/repl.py
@@ -1,0 +1,16 @@
+"""repl command — open an interactive REPL on the device."""
+
+import typer
+
+from brasa.cli import app
+from brasa.core.device import repl as device_repl
+from brasa.core.lock import port_lock
+from brasa.core.port import detect_port
+
+
+@app.command()
+def repl(ctx: typer.Context) -> None:
+    """Open an interactive REPL on the device."""
+    port = (ctx.obj.get("port") if ctx.obj else None) or detect_port()
+    with port_lock(port, "repl"):
+        device_repl(port)

--- a/src/brasa/commands/restart.py
+++ b/src/brasa/commands/restart.py
@@ -1,0 +1,18 @@
+"""restart command — reboot the MicroPython device."""
+
+import typer
+
+from brasa.cli import app
+from brasa.core.device import reset
+from brasa.core.lock import port_lock
+from brasa.core.output import success
+from brasa.core.port import detect_port
+
+
+@app.command()
+def restart(ctx: typer.Context) -> None:
+    """Reboot the MicroPython device."""
+    port = (ctx.obj.get("port") if ctx.obj else None) or detect_port()
+    with port_lock(port, "restart"):
+        reset(port)
+        success("device restarted")

--- a/src/brasa/commands/serial.py
+++ b/src/brasa/commands/serial.py
@@ -1,0 +1,20 @@
+"""serial command — monitor serial output from a MicroPython device."""
+
+import typer
+
+from brasa.cli import app
+from brasa.core.lock import port_lock
+from brasa.core.port import detect_port
+from brasa.core.serial import SerialReader
+
+
+@app.command()
+def serial(
+    ctx: typer.Context,
+    baud: int = typer.Option(115200, "--baud", "-b", help="Baud rate"),
+) -> None:
+    """Monitor serial output from a MicroPython device."""
+    port = (ctx.obj.get("port") if ctx.obj else None) or detect_port()
+    with port_lock(port, "serial"):
+        reader = SerialReader(port, baud=baud)
+        reader.run_blocking()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,118 @@
+"""Tests for CLI commands: detect, serial, repl, restart, exec."""
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from brasa.cli import app
+
+runner = CliRunner()
+
+
+# ── detect ──────────────────────────────────────────────────────────────────
+
+
+def test_detect_with_port_override() -> None:
+    result = runner.invoke(app, ["--port", "/dev/ttyUSB0", "detect"])
+    assert result.exit_code == 0
+    assert "/dev/ttyUSB0" in result.output
+
+
+@patch("brasa.commands.detect.detect_port", return_value="/dev/cu.autodetected")
+def test_detect_auto(mock_detect: MagicMock) -> None:
+    result = runner.invoke(app, ["detect"])
+    assert result.exit_code == 0
+    assert "/dev/cu.autodetected" in result.output
+    mock_detect.assert_called_once()
+
+
+# ── serial ──────────────────────────────────────────────────────────────────
+
+
+@patch("brasa.commands.serial.SerialReader")
+@patch("brasa.commands.serial.port_lock", return_value=nullcontext())
+@patch("brasa.commands.serial.detect_port", return_value="/dev/cu.test")
+def test_serial(mock_detect: MagicMock, mock_lock: MagicMock, mock_reader_cls: MagicMock) -> None:
+    result = runner.invoke(app, ["serial"])
+    assert result.exit_code == 0
+    mock_reader_cls.assert_called_once_with("/dev/cu.test", baud=115200)
+    mock_reader_cls.return_value.run_blocking.assert_called_once()
+
+
+@patch("brasa.commands.serial.SerialReader")
+@patch("brasa.commands.serial.port_lock", return_value=nullcontext())
+def test_serial_with_port_and_baud(mock_lock: MagicMock, mock_reader_cls: MagicMock) -> None:
+    result = runner.invoke(app, ["--port", "/dev/ttyS0", "serial", "--baud", "9600"])
+    assert result.exit_code == 0
+    mock_reader_cls.assert_called_once_with("/dev/ttyS0", baud=9600)
+
+
+# ── repl ────────────────────────────────────────────────────────────────────
+
+
+@patch("brasa.commands.repl.device_repl")
+@patch("brasa.commands.repl.port_lock", return_value=nullcontext())
+@patch("brasa.commands.repl.detect_port", return_value="/dev/cu.test")
+def test_repl(mock_detect: MagicMock, mock_lock: MagicMock, mock_repl: MagicMock) -> None:
+    result = runner.invoke(app, ["repl"])
+    assert result.exit_code == 0
+    mock_repl.assert_called_once_with("/dev/cu.test")
+
+
+@patch("brasa.commands.repl.device_repl")
+@patch("brasa.commands.repl.port_lock", return_value=nullcontext())
+def test_repl_with_port_override(mock_lock: MagicMock, mock_repl: MagicMock) -> None:
+    result = runner.invoke(app, ["--port", "/dev/cu.custom", "repl"])
+    assert result.exit_code == 0
+    mock_repl.assert_called_once_with("/dev/cu.custom")
+
+
+# ── restart ─────────────────────────────────────────────────────────────────
+
+
+@patch("brasa.commands.restart.port_lock", return_value=nullcontext())
+@patch("brasa.commands.restart.reset")
+@patch("brasa.commands.restart.detect_port", return_value="/dev/cu.test")
+def test_restart(mock_detect: MagicMock, mock_reset: MagicMock, mock_lock: MagicMock) -> None:
+    result = runner.invoke(app, ["restart"])
+    assert result.exit_code == 0
+    mock_reset.assert_called_once_with("/dev/cu.test")
+
+
+@patch("brasa.commands.restart.port_lock", return_value=nullcontext())
+@patch("brasa.commands.restart.reset")
+def test_restart_with_port_override(mock_reset: MagicMock, mock_lock: MagicMock) -> None:
+    result = runner.invoke(app, ["--port", "/dev/cu.manual", "restart"])
+    assert result.exit_code == 0
+    mock_reset.assert_called_once_with("/dev/cu.manual")
+
+
+# ── exec ────────────────────────────────────────────────────────────────────
+
+
+@patch("brasa.commands.exec.port_lock", return_value=nullcontext())
+@patch("brasa.commands.exec.exec_expr", return_value="42")
+@patch("brasa.commands.exec.detect_port", return_value="/dev/cu.test")
+def test_exec(mock_detect: MagicMock, mock_exec: MagicMock, mock_lock: MagicMock) -> None:
+    result = runner.invoke(app, ["exec", "print(1)"])
+    assert result.exit_code == 0
+    mock_exec.assert_called_once_with("/dev/cu.test", "print(1)")
+    assert "42" in result.output
+
+
+@patch("brasa.commands.exec.port_lock", return_value=nullcontext())
+@patch("brasa.commands.exec.exec_expr", return_value="")
+@patch("brasa.commands.exec.detect_port", return_value="/dev/cu.test")
+def test_exec_empty_result(mock_detect: MagicMock, mock_exec: MagicMock, mock_lock: MagicMock) -> None:
+    result = runner.invoke(app, ["exec", "pass"])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+@patch("brasa.commands.exec.port_lock", return_value=nullcontext())
+@patch("brasa.commands.exec.exec_expr", return_value="hello")
+def test_exec_with_port_override(mock_exec: MagicMock, mock_lock: MagicMock) -> None:
+    result = runner.invoke(app, ["--port", "/dev/cu.manual", "exec", "expr"])
+    assert result.exit_code == 0
+    mock_exec.assert_called_once_with("/dev/cu.manual", "expr")


### PR DESCRIPTION
## Summary
- Add 5 command modules: detect, serial, repl, restart, exec
- Add global `--port` / `-p` option to CLI callback
- Wire all commands into `cli.py` via command registration
- Add tests in `tests/test_commands.py`

Closes #14

## Test plan
- [x] `uv run pytest` passes (all 59 tests)
- [x] `uv run ruff check src/` passes
- [x] `brasa --help` shows all 5 commands