### PR TITLE
add make setup target with pre-commit install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: install lint format typecheck test test-cov check
+.PHONY: setup install lint format typecheck test test-cov check
 
-install:
+setup:
 	uv sync
+	uv run pre-commit install
+
+install: setup
 
 lint:
 	uv run ruff check src/


### PR DESCRIPTION
## Summary
- Add `setup` target to Makefile that runs `uv sync` and `uv run pre-commit install`
- Keep `install` as a backwards-compatible alias for `setup`
- Ensures pre-commit hooks are installed for local development

## Test plan
- [x] `make setup` installs deps and hooks
- [x] `make install` still works (alias)
- [x] All existing checks pass (`make check`)