### PR TITLE
Add config loading and deploy command

### DIFF
--- a/src/brasa/cli.py
+++ b/src/brasa/cli.py
@@ -31,6 +31,7 @@ def _main(
 
 # Register commands — imported after `app` is defined to avoid circular imports.
 from brasa.commands import (  # noqa: E402, F811
+    deploy,
     detect,
     diff,
     exec,
@@ -41,7 +42,7 @@ from brasa.commands import (  # noqa: E402, F811
 )
 
 # Keep references so linters don't flag unused imports.
-__all__ = ["detect", "diff", "exec", "flash", "repl", "restart", "serial"]
+__all__ = ["deploy", "detect", "diff", "exec", "flash", "repl", "restart", "serial"]
 
 
 def main() -> None:

--- a/src/brasa/commands/deploy.py
+++ b/src/brasa/commands/deploy.py
@@ -1,0 +1,22 @@
+"""deploy command — compile and push project files to the device."""
+
+import typer
+
+from brasa.cli import app
+from brasa.core.config import require_config
+from brasa.core.deploy import deploy as deploy_to_device
+from brasa.core.device import dtr_reset
+from brasa.core.lock import port_lock
+from brasa.core.output import success
+from brasa.core.port import detect_port
+
+
+@app.command()
+def deploy(ctx: typer.Context) -> None:
+    """Compile and push project files to the device."""
+    cfg = require_config()
+    port = (ctx.obj.get("port") if ctx.obj else None) or detect_port()
+    with port_lock(port, "deploy"):
+        deploy_to_device(port, cfg.deploy)
+        dtr_reset(port)
+        success("deploy complete")

--- a/src/brasa/core/deploy.py
+++ b/src/brasa/core/deploy.py
@@ -1,0 +1,74 @@
+"""Deploy project files to a MicroPython device."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from brasa.core.config import DeployConfig
+from brasa.core.device import fs_cp, mpremote_run
+from brasa.core.output import error, status
+
+
+def deploy(port: str, cfg: DeployConfig) -> None:
+    """Deploy project files to the device. Caller must hold the port lock."""
+    _copy_boot_files(port, cfg)
+    if cfg.romfs:
+        _deploy_romfs(port, cfg)
+    else:
+        _deploy_flat(port, cfg)
+
+
+def _copy_boot_files(port: str, cfg: DeployConfig) -> None:
+    """Copy env_file and boot_files to the device root."""
+    env_path = Path(cfg.env_file)
+    if not env_path.is_file():
+        error(f"env file not found: {cfg.env_file}")
+        raise SystemExit(1)
+
+    status("deploy", f"copying {cfg.env_file}")
+    fs_cp(port, cfg.env_file, ":/")
+
+    for boot_file in cfg.boot_files:
+        if Path(boot_file).is_file():
+            status("deploy", f"copying {boot_file}")
+            fs_cp(port, boot_file, ":/")
+
+
+def _deploy_romfs(port: str, cfg: DeployConfig) -> None:
+    """Deploy source files via mpremote romfs (with optional mpy compilation)."""
+    src_dir = Path(cfg.src)
+    tmpdir = tempfile.mkdtemp(prefix="brasa-deploy-")
+
+    try:
+        exclude = set(cfg.boot_files) | {cfg.env_file}
+        for py_file in src_dir.rglob("*.py"):
+            if py_file.name in exclude:
+                continue
+            # Preserve directory structure relative to src.
+            rel = py_file.relative_to(src_dir)
+            dest = Path(tmpdir) / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(py_file, dest)
+
+        status("deploy", f"deploying via romfs from {cfg.src}/")
+        args: list[str] = ["romfs"]
+        if cfg.mpy_compile:
+            args.append("--mpy")
+        args.extend(["deploy", tmpdir + "/"])
+        mpremote_run(port, *args)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _deploy_flat(port: str, cfg: DeployConfig) -> None:
+    """Copy all source files to the device root (no romfs)."""
+    src_dir = Path(cfg.src)
+    exclude = set(cfg.boot_files) | {cfg.env_file}
+
+    for src_file in src_dir.rglob("*"):
+        if not src_file.is_file():
+            continue
+        if src_file.name in exclude:
+            continue
+        status("deploy", f"copying {src_file}")
+        fs_cp(port, str(src_file), ":/")

--- a/tests/test_commands_deploy.py
+++ b/tests/test_commands_deploy.py
@@ -1,0 +1,53 @@
+"""Tests for brasa.commands.deploy — deploy command wiring."""
+
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from brasa.cli import app
+from brasa.core.config import BrasaConfig
+
+runner = CliRunner()
+
+
+@patch("brasa.commands.deploy.success")
+@patch("brasa.commands.deploy.dtr_reset")
+@patch("brasa.commands.deploy.deploy_to_device")
+@patch("brasa.commands.deploy.port_lock", return_value=nullcontext())
+@patch("brasa.commands.deploy.detect_port", return_value="/dev/cu.test")
+@patch("brasa.commands.deploy.require_config", return_value=BrasaConfig())
+def test_deploy_command(
+    mock_config: MagicMock,
+    mock_detect: MagicMock,
+    mock_lock: MagicMock,
+    mock_deploy: MagicMock,
+    mock_reset: MagicMock,
+    mock_success: MagicMock,
+) -> None:
+    """deploy command wires config, lock, deploy, and reset together."""
+    result = runner.invoke(app, ["deploy"])
+    assert result.exit_code == 0
+    mock_config.assert_called_once()
+    mock_deploy.assert_called_once_with("/dev/cu.test", BrasaConfig().deploy)
+    mock_reset.assert_called_once_with("/dev/cu.test")
+    mock_success.assert_called_once()
+
+
+@patch("brasa.commands.deploy.success")
+@patch("brasa.commands.deploy.dtr_reset")
+@patch("brasa.commands.deploy.deploy_to_device")
+@patch("brasa.commands.deploy.port_lock", return_value=nullcontext())
+@patch("brasa.commands.deploy.require_config", return_value=BrasaConfig())
+def test_deploy_with_port_override(
+    mock_config: MagicMock,
+    mock_lock: MagicMock,
+    mock_deploy: MagicMock,
+    mock_reset: MagicMock,
+    mock_success: MagicMock,
+) -> None:
+    """deploy command uses --port override when provided."""
+    result = runner.invoke(app, ["--port", "/dev/cu.manual", "deploy"])
+    assert result.exit_code == 0
+    mock_deploy.assert_called_once_with("/dev/cu.manual", BrasaConfig().deploy)
+    mock_reset.assert_called_once_with("/dev/cu.manual")

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,141 @@
+"""Tests for brasa.core.deploy — deploy logic."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from brasa.core.config import DeployConfig
+from brasa.core.deploy import deploy
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a minimal project layout and chdir into it."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text("# app")
+    (src / "utils.py").write_text("# utils")
+    (tmp_path / ".env").write_text("SECRET=123")
+    (tmp_path / "boot.py").write_text("# boot")
+    (tmp_path / "main.py").write_text("# main")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@patch("brasa.core.deploy.mpremote_run")
+@patch("brasa.core.deploy.fs_cp")
+def test_deploy_romfs(
+    mock_fs_cp: MagicMock, mock_mpremote: MagicMock, project_dir: Path
+) -> None:
+    """ROMFS deploy copies boot files then calls mpremote romfs with --mpy."""
+    cfg = DeployConfig()
+    deploy("/dev/cu.test", cfg)
+
+    # Boot files copied.
+    assert call("/dev/cu.test", ".env", ":/") in mock_fs_cp.call_args_list
+    assert call("/dev/cu.test", "boot.py", ":/") in mock_fs_cp.call_args_list
+    assert call("/dev/cu.test", "main.py", ":/") in mock_fs_cp.call_args_list
+
+    # mpremote romfs called with --mpy.
+    mock_mpremote.assert_called_once()
+    args = mock_mpremote.call_args[0]
+    assert args[0] == "/dev/cu.test"
+    assert "romfs" in args
+    assert "--mpy" in args
+    assert "deploy" in args
+
+
+@patch("brasa.core.deploy.mpremote_run")
+@patch("brasa.core.deploy.fs_cp")
+def test_deploy_romfs_no_mpy(
+    mock_fs_cp: MagicMock, mock_mpremote: MagicMock, project_dir: Path
+) -> None:
+    """ROMFS deploy without mpy_compile omits --mpy."""
+    cfg = DeployConfig(mpy_compile=False)
+    deploy("/dev/cu.test", cfg)
+
+    args = mock_mpremote.call_args[0]
+    assert "--mpy" not in args
+    assert "romfs" in args
+    assert "deploy" in args
+
+
+@patch("brasa.core.deploy.mpremote_run")
+@patch("brasa.core.deploy.fs_cp")
+def test_deploy_flat(
+    mock_fs_cp: MagicMock, mock_mpremote: MagicMock, project_dir: Path
+) -> None:
+    """Flat deploy copies all src files to device root."""
+    cfg = DeployConfig(romfs=False)
+    deploy("/dev/cu.test", cfg)
+
+    # mpremote romfs is NOT called.
+    mock_mpremote.assert_not_called()
+
+    # Boot files + source files copied via fs_cp.
+    cp_calls = mock_fs_cp.call_args_list
+    copied_srcs = [c[0][1] for c in cp_calls]
+    # env_file and boot files.
+    assert ".env" in copied_srcs
+    assert "boot.py" in copied_srcs
+    assert "main.py" in copied_srcs
+    # Source files.
+    assert any("app.py" in s for s in copied_srcs)
+    assert any("utils.py" in s for s in copied_srcs)
+
+
+@patch("brasa.core.deploy.fs_cp")
+def test_deploy_missing_env_file(
+    mock_fs_cp: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deploy errors when env_file is missing."""
+    src = tmp_path / "src"
+    src.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    cfg = DeployConfig()
+    with pytest.raises(SystemExit):
+        deploy("/dev/cu.test", cfg)
+
+    mock_fs_cp.assert_not_called()
+
+
+@patch("brasa.core.deploy.mpremote_run")
+@patch("brasa.core.deploy.fs_cp")
+def test_deploy_skips_missing_boot_files(
+    mock_fs_cp: MagicMock, mock_mpremote: MagicMock, project_dir: Path
+) -> None:
+    """Boot files that don't exist on disk are silently skipped."""
+    # Remove main.py so only boot.py remains.
+    (project_dir / "main.py").unlink()
+
+    cfg = DeployConfig()
+    deploy("/dev/cu.test", cfg)
+
+    copied = [c[0][1] for c in mock_fs_cp.call_args_list]
+    assert "boot.py" in copied
+    assert "main.py" not in copied
+
+
+@patch("brasa.core.deploy.mpremote_run")
+@patch("brasa.core.deploy.fs_cp")
+def test_deploy_romfs_temp_dir_cleaned(
+    mock_fs_cp: MagicMock, mock_mpremote: MagicMock, project_dir: Path
+) -> None:
+    """The temp directory is cleaned up after romfs deploy."""
+    cfg = DeployConfig()
+    deploy("/dev/cu.test", cfg)
+
+    # Extract the tmpdir from the mpremote call.
+    args = mock_mpremote.call_args[0]
+    tmpdir = args[-1].rstrip("/")
+    assert not Path(tmpdir).exists()
+
+
+def test_deploy_module_does_not_import_port_lock() -> None:
+    """deploy module does not import port_lock — locking is the caller's job."""
+    import brasa.core.deploy as deploy_mod
+
+    symbols = dir(deploy_mod)
+    assert "port_lock" not in symbols


### PR DESCRIPTION
## Summary
- **Config module** (`core/config.py`): loads project settings from `brasa.toml` or `[tool.brasa]` in `pyproject.toml` with frozen dataclass hierarchy (`BrasaConfig`, `FirmwareConfig`, `DeployConfig`, `SerialConfig`, `PortConfig`). `load_config()` returns defaults if no file found; `require_config()` exits with an error.
- **Deploy logic** (`core/deploy.py`): copies boot files (env_file + boot_files) then deploys source via romfs (`mpremote romfs --mpy deploy`) or flat `fs_cp`. Does NOT acquire port lock — caller is responsible, enabling reentrant use from future `dev` command.
- **Deploy command** (`commands/deploy.py`): wires config, port detection, locking, deploy, DTR reset, and success message.

Closes #15, closes #17

## Test plan
- [x] 9 config tests: defaults, brasa.toml, pyproject.toml fallback, precedence, partial config, require_config error, tuple conversion
- [x] 7 deploy logic tests: romfs with/without mpy, flat mode, missing env_file error, skipped boot files, temp dir cleanup, no port_lock import
- [x] 2 command wiring tests: auto-detect and port override
- [x] All 77 tests pass, ruff clean, ty clean