### PR TITLE
Add config loading and diff command

### DIFF
--- a/src/brasa/cli.py
+++ b/src/brasa/cli.py
@@ -32,6 +32,7 @@ def _main(
 # Register commands — imported after `app` is defined to avoid circular imports.
 from brasa.commands import (  # noqa: E402, F811
     detect,
+    diff,
     exec,
     flash,
     repl,
@@ -40,7 +41,7 @@ from brasa.commands import (  # noqa: E402, F811
 )
 
 # Keep references so linters don't flag unused imports.
-__all__ = ["detect", "exec", "flash", "repl", "restart", "serial"]
+__all__ = ["detect", "diff", "exec", "flash", "repl", "restart", "serial"]
 
 
 def main() -> None:

--- a/src/brasa/commands/diff.py
+++ b/src/brasa/commands/diff.py
@@ -1,0 +1,19 @@
+"""diff command — show differences between local src/ and device files."""
+
+import typer
+
+from brasa.cli import app
+from brasa.core.config import require_config
+from brasa.core.diff import diff_files, print_diff
+from brasa.core.lock import port_lock
+from brasa.core.port import detect_port
+
+
+@app.command()
+def diff(ctx: typer.Context) -> None:
+    """Show differences between local src/ and device files."""
+    cfg = require_config()
+    port = (ctx.obj.get("port") if ctx.obj else None) or detect_port()
+    with port_lock(port, "diff"):
+        diffs = diff_files(port, cfg.deploy)
+        print_diff(diffs)

--- a/src/brasa/core/diff.py
+++ b/src/brasa/core/diff.py
@@ -1,0 +1,113 @@
+"""Diff logic — compare local source files against device files."""
+
+import difflib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from brasa.core.config import DeployConfig
+from brasa.core.device import fs_cat, fs_ls
+from brasa.core.output import cyan, dim, green, red, success
+
+
+@dataclass
+class FileDiff:
+    path: str
+    status: str  # "modified", "local_only", "device_only"
+    diff_lines: list[str]  # unified diff lines, empty for non-modified
+
+
+def _parse_device_filenames(listing: str) -> set[str]:
+    """Extract filenames from fs_ls output (lines like '       123 boot.py')."""
+    names: set[str] = set()
+    for line in listing.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split(None, 1)
+        if len(parts) == 2:
+            names.add(parts[1])
+    return names
+
+
+def diff_files(port: str, cfg: DeployConfig) -> list[FileDiff]:
+    """Compare local src/*.py files with device files. Skip .env."""
+    src_dir = Path(cfg.src)
+    local_files: set[str] = set()
+    if src_dir.is_dir():
+        local_files = {p.name for p in src_dir.glob("*.py")}
+
+    listing = fs_ls(port, "/")
+    device_files = {
+        name for name in _parse_device_filenames(listing) if name.endswith(".py")
+    }
+
+    diffs: list[FileDiff] = []
+
+    # Files present on both sides.
+    for name in sorted(local_files & device_files):
+        local_content = (src_dir / name).read_text()
+        device_content = fs_cat(port, f"/{name}")
+        if local_content == device_content:
+            continue
+        diff_lines = list(
+            difflib.unified_diff(
+                device_content.splitlines(keepends=True),
+                local_content.splitlines(keepends=True),
+                fromfile=f"device:/{name}",
+                tofile=f"local:{cfg.src}/{name}",
+            )
+        )
+        diffs.append(FileDiff(path=name, status="modified", diff_lines=diff_lines))
+
+    # Local-only files.
+    for name in sorted(local_files - device_files):
+        diffs.append(FileDiff(path=name, status="local_only", diff_lines=[]))
+
+    # Device-only files.
+    for name in sorted(device_files - local_files):
+        diffs.append(FileDiff(path=name, status="device_only", diff_lines=[]))
+
+    return diffs
+
+
+def print_diff(diffs: list[FileDiff]) -> None:
+    """Print colored diff output to stderr."""
+    if not diffs:
+        success("Device is up to date")
+        return
+
+    modified = 0
+    local_only = 0
+    device_only = 0
+
+    for fd in diffs:
+        if fd.status == "modified":
+            modified += 1
+            for line in fd.diff_lines:
+                text = line.rstrip("\n")
+                if text.startswith("---") or text.startswith("+++"):
+                    print(cyan(text), file=sys.stderr)
+                elif text.startswith("@@"):
+                    print(cyan(text), file=sys.stderr)
+                elif text.startswith("-"):
+                    print(red(text), file=sys.stderr)
+                elif text.startswith("+"):
+                    print(green(text), file=sys.stderr)
+                else:
+                    print(dim(text), file=sys.stderr)
+        elif fd.status == "local_only":
+            local_only += 1
+            print(green(f"Only local: {fd.path}"), file=sys.stderr)
+        elif fd.status == "device_only":
+            device_only += 1
+            print(red(f"Only on device: {fd.path}"), file=sys.stderr)
+
+    parts: list[str] = []
+    if modified:
+        parts.append(f"{modified} modified")
+    if local_only:
+        parts.append(f"{local_only} local only")
+    if device_only:
+        parts.append(f"{device_only} device only")
+    print(dim(f"\n{', '.join(parts)}"), file=sys.stderr)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,195 @@
+"""Tests for brasa.core.diff — file comparison logic and diff command."""
+
+from contextlib import nullcontext
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from brasa.cli import app
+from brasa.core.config import DeployConfig
+from brasa.core.diff import FileDiff, diff_files, print_diff
+
+runner = CliRunner()
+
+DEVICE_LS_OUTPUT = """\
+       123 boot.py
+       456 main.py
+       789 helper.py
+        42 .env
+"""
+
+
+def _setup_local(tmp_path: Path, files: dict[str, str]) -> DeployConfig:
+    """Create local files in tmp_path/src and return a DeployConfig pointing there."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir(exist_ok=True)
+    for name, content in files.items():
+        (src_dir / name).write_text(content)
+    return DeployConfig(src=str(src_dir))
+
+
+# ── diff_files ─────────────────────────────────────────────────────────────
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls", return_value=DEVICE_LS_OUTPUT)
+def test_identical_files_no_diff(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    cfg = _setup_local(tmp_path, {"boot.py": "# boot", "main.py": "# main"})
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# boot",
+        "/main.py": "# main",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    # helper.py is device-only
+    assert len(diffs) == 1
+    assert diffs[0].status == "device_only"
+    assert diffs[0].path == "helper.py"
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls", return_value=DEVICE_LS_OUTPUT)
+def test_modified_file(mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path) -> None:
+    cfg = _setup_local(
+        tmp_path,
+        {"boot.py": "# local boot\n", "main.py": "# main", "helper.py": "# helper"},
+    )
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# device boot\n",
+        "/main.py": "# main",
+        "/helper.py": "# helper",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    modified = [d for d in diffs if d.status == "modified"]
+    assert len(modified) == 1
+    assert modified[0].path == "boot.py"
+    assert any("device:/boot.py" in line for line in modified[0].diff_lines)
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls", return_value="       10 boot.py\n")
+def test_local_only_file(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    cfg = _setup_local(tmp_path, {"boot.py": "# boot", "extra.py": "# extra"})
+    mock_cat.return_value = "# boot"
+
+    diffs = diff_files("/dev/test", cfg)
+    local_only = [d for d in diffs if d.status == "local_only"]
+    assert len(local_only) == 1
+    assert local_only[0].path == "extra.py"
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls", return_value="       10 boot.py\n       20 orphan.py\n")
+def test_device_only_file(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    cfg = _setup_local(tmp_path, {"boot.py": "# boot"})
+    mock_cat.return_value = "# boot"
+
+    diffs = diff_files("/dev/test", cfg)
+    device_only = [d for d in diffs if d.status == "device_only"]
+    assert len(device_only) == 1
+    assert device_only[0].path == "orphan.py"
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls", return_value="       10 .env\n       20 boot.py\n")
+def test_env_excluded(mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path) -> None:
+    cfg = _setup_local(tmp_path, {"boot.py": "# boot", ".env": "SECRET=1"})
+    mock_cat.return_value = "# boot"
+
+    diffs = diff_files("/dev/test", cfg)
+    assert all(d.path != ".env" for d in diffs)
+
+
+# ── print_diff ─────────────────────────────────────────────────────────────
+
+
+def test_print_diff_no_diffs(capsys: pytest.CaptureFixture[str]) -> None:
+    print_diff([])
+    captured = capsys.readouterr()
+    assert "up to date" in captured.err.lower()
+
+
+def test_print_diff_with_modified(capsys: pytest.CaptureFixture[str]) -> None:
+    diffs = [
+        FileDiff(
+            path="boot.py",
+            status="modified",
+            diff_lines=[
+                "--- device:/boot.py\n",
+                "+++ local:src/boot.py\n",
+                "@@ -1 +1 @@\n",
+                "-old\n",
+                "+new\n",
+            ],
+        ),
+    ]
+    print_diff(diffs)
+    captured = capsys.readouterr()
+    assert "1 modified" in captured.err
+
+
+def test_print_diff_with_local_and_device_only(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    diffs = [
+        FileDiff(path="new.py", status="local_only", diff_lines=[]),
+        FileDiff(path="old.py", status="device_only", diff_lines=[]),
+    ]
+    print_diff(diffs)
+    captured = capsys.readouterr()
+    assert "Only local: new.py" in captured.err
+    assert "Only on device: old.py" in captured.err
+    assert "1 local only" in captured.err
+    assert "1 device only" in captured.err
+
+
+# ── diff command wiring ────────────────────────────────────────────────────
+
+
+@patch("brasa.commands.diff.print_diff")
+@patch("brasa.commands.diff.diff_files", return_value=[])
+@patch("brasa.commands.diff.port_lock", return_value=nullcontext())
+@patch("brasa.commands.diff.detect_port", return_value="/dev/cu.test")
+@patch(
+    "brasa.commands.diff.require_config",
+    return_value=MagicMock(deploy=DeployConfig()),
+)
+def test_diff_command(
+    mock_config: MagicMock,
+    mock_detect: MagicMock,
+    mock_lock: MagicMock,
+    mock_diff_files: MagicMock,
+    mock_print: MagicMock,
+) -> None:
+    result = runner.invoke(app, ["diff"])
+    assert result.exit_code == 0
+    mock_config.assert_called_once()
+    mock_diff_files.assert_called_once()
+    mock_print.assert_called_once()
+
+
+@patch("brasa.commands.diff.print_diff")
+@patch("brasa.commands.diff.diff_files", return_value=[])
+@patch("brasa.commands.diff.port_lock", return_value=nullcontext())
+@patch(
+    "brasa.commands.diff.require_config",
+    return_value=MagicMock(deploy=DeployConfig()),
+)
+def test_diff_command_with_port_override(
+    mock_config: MagicMock,
+    mock_lock: MagicMock,
+    mock_diff_files: MagicMock,
+    mock_print: MagicMock,
+) -> None:
+    result = runner.invoke(app, ["--port", "/dev/cu.manual", "diff"])
+    assert result.exit_code == 0
+    mock_diff_files.assert_called_once_with("/dev/cu.manual", DeployConfig())


### PR DESCRIPTION
## Summary
- Implement `brasa.core.config` module: loads project settings from `brasa.toml` or `[tool.brasa]` in `pyproject.toml` with frozen dataclass models and sensible defaults (#15)
- Implement `brasa.core.diff` module and `brasa diff` command: compares local `src/*.py` files against device files via mpremote, showing colored unified diffs (#19)
- Register `diff` command in CLI entry point

## Test plan
- [x] Config: loading from `brasa.toml`, fallback to `pyproject.toml`, all-defaults, partial config, precedence, `require_config()` error path
- [x] Diff: identical files (no diff), modified files (unified diff output), local-only detection, device-only detection, `.env` exclusion, `print_diff` output formatting, command wiring via CliRunner
- [x] All 78 tests pass, type checking clean, linting clean

Closes #15, closes #19