### PR TITLE
update README with v0.3 commands and config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,76 @@
 
 MicroPython developer tools. Flash, deploy, watch, monitor.
 
+## Install
+
 ```
 pip install brasa
 ```
 
+## Commands
+
 ```
-brasa flash          # download firmware + flash device
+brasa dev            # deploy, watch for changes, stream serial
 brasa deploy         # compile & push src/ to device
-brasa dev            # deploy + watch for changes
+brasa flash          # download firmware + flash device
 brasa serial         # read-only serial monitor
 brasa repl           # interactive REPL
+brasa diff           # diff local src/ vs device files
 brasa detect         # show connected device port
-brasa diff           # diff local src/ vs device
 brasa exec "expr"    # run expression on device
 brasa restart        # reboot device
+```
+
+All commands auto-detect the serial port. Override with `--port /dev/cu.xxx`.
+
+## Configuration
+
+Create a `brasa.toml` in your project root (or add `[tool.brasa]` to `pyproject.toml`):
+
+```toml
+[firmware]
+board = "ESP8266"
+variant = "GENERIC-FLASH_2M_ROMFS"
+version = "1.27.0"
+date = "20251209"
+
+[deploy]
+src = "src"
+env_file = ".env"
+boot_files = ["boot.py", "main.py"]
+romfs = true
+mpy_compile = true
+
+[serial]
+baud_rate = 115200
+
+[port]
+patterns = ["/dev/cu.usbserial*", "/dev/cu.wchusbserial*", "/dev/cu.SLAB_USBtoUART*"]
+```
+
+Commands that don't need config (`detect`, `serial`, `repl`, `restart`, `exec`) work without it. Commands that do (`flash`, `deploy`, `dev`, `diff`) will error if no config is found.
+
+All fields have defaults — a minimal config works:
+
+```toml
+[firmware]
+version = "1.27.0"
+date = "20251209"
+```
+
+## Workflow
+
+```bash
+brasa flash          # flash firmware (first time or update)
+brasa dev            # deploy + watch + serial monitor (daily development)
+brasa diff           # check what's different on device
 ```
 
 ## Why
 
 Every MicroPython project re-invents the same Makefile: detect the serial port, lock it, flash firmware, deploy files, watch for changes, read serial output. Brasa replaces that with a single CLI that works across projects.
 
-## Status
+## Requirements
 
-Early development. See [HANDOFF.md](HANDOFF.md) for architecture and roadmap.
+- Python 3.12+
+- macOS or Linux


### PR DESCRIPTION
## Summary
- Add Configuration section with full brasa.toml reference and minimal example
- Add Workflow section showing typical usage pattern
- Add Requirements section (Python 3.12+, macOS/Linux)
- Lead with `brasa dev` as the flagship command
- Remove dead HANDOFF.md link