### PR TITLE
fix: use kebab-case esptool flags to resolve deprecation warnings

### DIFF
--- a/src/brasa/core/firmware.py
+++ b/src/brasa/core/firmware.py
@@ -56,7 +56,7 @@ def download_firmware(cfg: FirmwareConfig) -> Path:
 def flash_firmware(port: str, firmware_path: Path) -> None:
     """Erase flash then write firmware via esptool subprocess."""
     output.status("flash", f"erasing flash on {port}")
-    subprocess.run(["esptool", "--port", port, "erase_flash"], check=True)
+    subprocess.run(["esptool", "--port", port, "erase-flash"], check=True)
 
     output.status("flash", f"writing {firmware_path} to {port}")
     subprocess.run(
@@ -66,8 +66,8 @@ def flash_firmware(port: str, firmware_path: Path) -> None:
             port,
             "--baud",
             "460800",
-            "write_flash",
-            "--flash_size=detect",
+            "write-flash",
+            "--flash-size=detect",
             "0",
             str(firmware_path),
         ],

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -85,7 +85,7 @@ def test_download_firmware_downloads_when_not_cached(
 
 def test_flash_firmware_calls_esptool(fp) -> None:  # type: ignore[no-untyped-def]
     """Test that flash_firmware invokes esptool with correct arguments."""
-    fp.register(["esptool", "--port", "/dev/cu.test", "erase_flash"])
+    fp.register(["esptool", "--port", "/dev/cu.test", "erase-flash"])
     fp.register(
         [
             "esptool",
@@ -93,8 +93,8 @@ def test_flash_firmware_calls_esptool(fp) -> None:  # type: ignore[no-untyped-de
             "/dev/cu.test",
             "--baud",
             "460800",
-            "write_flash",
-            "--flash_size=detect",
+            "write-flash",
+            "--flash-size=detect",
             "0",
             "firmware/test.bin",
         ]
@@ -102,7 +102,7 @@ def test_flash_firmware_calls_esptool(fp) -> None:  # type: ignore[no-untyped-de
 
     flash_firmware("/dev/cu.test", Path("firmware/test.bin"))
 
-    assert fp.call_count(["esptool", "--port", "/dev/cu.test", "erase_flash"]) == 1
+    assert fp.call_count(["esptool", "--port", "/dev/cu.test", "erase-flash"]) == 1
     assert (
         fp.call_count(
             [
@@ -111,8 +111,8 @@ def test_flash_firmware_calls_esptool(fp) -> None:  # type: ignore[no-untyped-de
                 "/dev/cu.test",
                 "--baud",
                 "460800",
-                "write_flash",
-                "--flash_size=detect",
+                "write-flash",
+                "--flash-size=detect",
                 "0",
                 "firmware/test.bin",
             ]


### PR DESCRIPTION
## Summary
- Replace deprecated snake_case esptool subcommand and option names with kebab-case equivalents (`erase_flash` -> `erase-flash`, `write_flash` -> `write-flash`, `--flash_size=detect` -> `--flash-size=detect`)
- Update test expectations in `test_firmware.py` to match

Closes #46

## Test plan
- [x] All 105 existing tests pass
- [x] `test_flash_firmware_calls_esptool` validates the updated flag names
- [x] ruff format, ruff check, ty check all pass