### PR TITLE
fix: cache firmware in .brasa/firmware/ instead of firmware/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ dist/
 *.swp
 *.swo
 
+# Brasa cache
+.brasa/
+
 # OS
 .DS_Store

--- a/src/brasa/core/firmware.py
+++ b/src/brasa/core/firmware.py
@@ -22,8 +22,8 @@ def firmware_url(cfg: FirmwareConfig) -> str:
 
 
 def firmware_cache_path(cfg: FirmwareConfig) -> Path:
-    """Return the local cache path for the firmware binary (firmware/<filename>)."""
-    return Path("firmware") / _firmware_filename(cfg)
+    """Return the local cache path for the firmware binary (.brasa/firmware/<filename>)."""
+    return Path(".brasa/firmware") / _firmware_filename(cfg)
 
 
 def download_firmware(cfg: FirmwareConfig) -> Path:

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -33,7 +33,7 @@ def test_firmware_cache_path() -> None:
         board="ESP32", variant="GENERIC", version="1.23.0", date="2025-01-01"
     )
     path = firmware_cache_path(cfg)
-    assert path == Path("firmware/ESP32_GENERIC-2025-01-01-v1.23.0.bin")
+    assert path == Path(".brasa/firmware/ESP32_GENERIC-2025-01-01-v1.23.0.bin")
 
 
 # ── download_firmware — cached ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Move firmware download cache from `firmware/` to `.brasa/firmware/` so all brasa artifacts live under a single dot-directory
- Add `.brasa/` to `.gitignore` to exclude cache artifacts from version control
- Update test assertion to match new path

Closes #47

## Test plan
- [x] `test_firmware_cache_path` updated and passing with new `.brasa/firmware/` prefix
- [x] All 105 tests pass
- [x] Ruff lint/format and ty typecheck clean