### PR TITLE
Add .gitignore to .brasa/ cache directory

### DIFF
--- a/src/brasa/core/firmware.py
+++ b/src/brasa/core/firmware.py
@@ -37,6 +37,11 @@ def download_firmware(cfg: FirmwareConfig) -> Path:
     output.status("firmware", f"downloading {url}")
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    brasa_dir = path.parent.parent  # .brasa/
+    gitignore = brasa_dir / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*\n")
+
     with httpx.stream("GET", url, follow_redirects=True) as response:
         response.raise_for_status()
         total = int(response.headers.get("content-length", 0))


### PR DESCRIPTION
## Summary
- Writes `.brasa/.gitignore` containing `*` when the cache directory is first created during firmware download
- Prevents cached firmware binaries from being accidentally committed to the consumer's repository

Closes #57

## Test plan
- [x] All 106 existing tests pass (including the mocked download test)
- [x] ruff check, ruff format, ty check all clean
- [ ] Manual: run `brasa flash` on a project, verify `.brasa/.gitignore` is created with `*` content