### PR TITLE
fix diff command for ROMFS deployments (#56)

### DIFF
--- a/src/brasa/core/config.py
+++ b/src/brasa/core/config.py
@@ -28,6 +28,13 @@ class DeployConfig:
     romfs: bool = True
     mpy_compile: bool = True
 
+    @property
+    def excluded_filenames(self) -> set[str]:
+        """Return bare filenames that should be excluded from source deploys."""
+        return {Path(name).name for name in self.boot_files} | {
+            Path(self.env_file).name
+        }
+
 
 @dataclass(frozen=True)
 class SerialConfig:

--- a/src/brasa/core/deploy.py
+++ b/src/brasa/core/deploy.py
@@ -9,11 +9,6 @@ from brasa.core.device import fs_cp, mpremote_run
 from brasa.core.output import error, status
 
 
-def _excluded_filenames(cfg: DeployConfig) -> set[str]:
-    """Return bare filenames that should be excluded from source deploys."""
-    return {Path(name).name for name in cfg.boot_files} | {Path(cfg.env_file).name}
-
-
 def deploy(port: str, cfg: DeployConfig) -> None:
     """Deploy project files to the device. Caller must hold the port lock."""
     _copy_boot_files(port, cfg)
@@ -48,7 +43,7 @@ def _deploy_romfs(port: str, cfg: DeployConfig) -> None:
     tmpdir = tempfile.mkdtemp(prefix="brasa-deploy-")
 
     try:
-        exclude = _excluded_filenames(cfg)
+        exclude = cfg.excluded_filenames
         for py_file in src_dir.rglob("*.py"):
             if py_file.name in exclude:
                 continue
@@ -77,7 +72,7 @@ def _deploy_romfs(port: str, cfg: DeployConfig) -> None:
 def _deploy_flat(port: str, cfg: DeployConfig) -> None:
     """Copy all source files to the device root (no romfs)."""
     src_dir = Path(cfg.src)
-    exclude = _excluded_filenames(cfg)
+    exclude = cfg.excluded_filenames
 
     for src_file in src_dir.rglob("*"):
         if not src_file.is_file():

--- a/src/brasa/core/diff.py
+++ b/src/brasa/core/diff.py
@@ -1,6 +1,7 @@
 """Diff logic — compare local source files against device files."""
 
 import difflib
+import subprocess
 import sys
 from dataclasses import dataclass
 from enum import Enum
@@ -15,6 +16,7 @@ class DiffStatus(Enum):
     MODIFIED = "modified"
     LOCAL_ONLY = "local_only"
     DEVICE_ONLY = "device_only"
+    ROMFS = "romfs"
 
 
 @dataclass
@@ -37,21 +39,15 @@ def _parse_device_filenames(listing: str) -> set[str]:
     return names
 
 
-def diff_files(port: str, cfg: DeployConfig) -> list[FileDiff]:
-    """Compare local src/*.py files with device files. Skip .env."""
-    src_dir = Path(cfg.src)
-    local_files: set[str] = set()
-    if src_dir.is_dir():
-        local_files = {p.name for p in src_dir.glob("*.py")}
-
-    listing = fs_ls(port, "/")
-    device_files = {
-        name for name in _parse_device_filenames(listing) if name.endswith(".py")
-    }
-
+def _diff_text_files(
+    port: str,
+    cfg: DeployConfig,
+    src_dir: Path,
+    local_files: set[str],
+    device_files: set[str],
+) -> list[FileDiff]:
+    """Compare files present on both local and device, returning diffs for modified ones."""
     diffs: list[FileDiff] = []
-
-    # Files present on both sides.
     for name in sorted(local_files & device_files):
         local_content = (src_dir / name).read_text()
         device_content = fs_cat(port, f"/{name}")
@@ -68,16 +64,100 @@ def diff_files(port: str, cfg: DeployConfig) -> list[FileDiff]:
         diffs.append(
             FileDiff(path=name, status=DiffStatus.MODIFIED, diff_lines=diff_lines)
         )
+    return diffs
 
-    # Local-only files.
+
+def _diff_flat(
+    port: str, cfg: DeployConfig, src_dir: Path, local_files: set[str]
+) -> list[FileDiff]:
+    """Flat (non-ROMFS) diff: compare all local .py against device root .py files."""
+    listing = fs_ls(port, "/")
+    device_files = {
+        name for name in _parse_device_filenames(listing) if name.endswith(".py")
+    }
+
+    diffs = _diff_text_files(port, cfg, src_dir, local_files, device_files)
+
     for name in sorted(local_files - device_files):
         diffs.append(FileDiff(path=name, status=DiffStatus.LOCAL_ONLY, diff_lines=[]))
 
-    # Device-only files.
     for name in sorted(device_files - local_files):
         diffs.append(FileDiff(path=name, status=DiffStatus.DEVICE_ONLY, diff_lines=[]))
 
     return diffs
+
+
+def _diff_romfs(
+    port: str, cfg: DeployConfig, src_dir: Path, local_files: set[str]
+) -> list[FileDiff]:
+    """ROMFS-aware diff: boot files diffed at root, others checked against /rom/."""
+    boot_names = {Path(b).name for b in cfg.boot_files}
+    env_name = Path(cfg.env_file).name
+    local_boot = local_files & boot_names
+    local_romfs = local_files - boot_names - {env_name}
+
+    # Get device root listing for boot file comparison.
+    root_listing = fs_ls(port, "/")
+    root_py_files = {
+        name for name in _parse_device_filenames(root_listing) if name.endswith(".py")
+    }
+
+    diffs: list[FileDiff] = []
+
+    # Text-diff boot files against device root.
+    diffs.extend(_diff_text_files(port, cfg, src_dir, local_boot, root_py_files))
+
+    # Boot files only local.
+    for name in sorted(local_boot - root_py_files):
+        diffs.append(FileDiff(path=name, status=DiffStatus.LOCAL_ONLY, diff_lines=[]))
+
+    # Stale .py at root that aren't boot files (leftover from previous flat deploy).
+    stale_root = root_py_files - boot_names
+    for name in sorted(stale_root):
+        diffs.append(FileDiff(path=name, status=DiffStatus.DEVICE_ONLY, diff_lines=[]))
+
+    # Check /rom/ for .mpy files.
+    try:
+        rom_listing = fs_ls(port, "/rom/")
+        rom_mpy_names = {
+            name
+            for name in _parse_device_filenames(rom_listing)
+            if name.endswith(".mpy")
+        }
+    except subprocess.CalledProcessError:
+        rom_mpy_names = set()
+
+    # Convert .mpy names to .py for matching.
+    rom_py_from_mpy = {name.removesuffix(".mpy") + ".py" for name in rom_mpy_names}
+
+    # Files in both local_romfs and device rom -> ROMFS.
+    for name in sorted(local_romfs & rom_py_from_mpy):
+        diffs.append(FileDiff(path=name, status=DiffStatus.ROMFS, diff_lines=[]))
+
+    # Files only in local_romfs -> LOCAL_ONLY.
+    for name in sorted(local_romfs - rom_py_from_mpy):
+        diffs.append(FileDiff(path=name, status=DiffStatus.LOCAL_ONLY, diff_lines=[]))
+
+    # .mpy files only on device -> DEVICE_ONLY (use the .mpy name).
+    device_only_mpy = rom_mpy_names - {
+        name.removesuffix(".py") + ".mpy" for name in local_romfs
+    }
+    for name in sorted(device_only_mpy):
+        diffs.append(FileDiff(path=name, status=DiffStatus.DEVICE_ONLY, diff_lines=[]))
+
+    return diffs
+
+
+def diff_files(port: str, cfg: DeployConfig) -> list[FileDiff]:
+    """Compare local src/*.py files with device files. Skip .env."""
+    src_dir = Path(cfg.src)
+    local_files: set[str] = set()
+    if src_dir.is_dir():
+        local_files = {p.name for p in src_dir.glob("*.py")}
+
+    if cfg.romfs:
+        return _diff_romfs(port, cfg, src_dir, local_files)
+    return _diff_flat(port, cfg, src_dir, local_files)
 
 
 def print_diff(diffs: list[FileDiff]) -> None:
@@ -89,6 +169,7 @@ def print_diff(diffs: list[FileDiff]) -> None:
     modified = 0
     local_only = 0
     device_only = 0
+    romfs = 0
 
     for fd in diffs:
         if fd.status == DiffStatus.MODIFIED:
@@ -111,6 +192,9 @@ def print_diff(diffs: list[FileDiff]) -> None:
         elif fd.status == DiffStatus.DEVICE_ONLY:
             device_only += 1
             print(red(f"Only on device: {fd.path}"), file=sys.stderr)
+        elif fd.status == DiffStatus.ROMFS:
+            romfs += 1
+            print(dim(f"Deployed (romfs): {fd.path}"), file=sys.stderr)
 
     parts: list[str] = []
     if modified:
@@ -119,4 +203,6 @@ def print_diff(diffs: list[FileDiff]) -> None:
         parts.append(f"{local_only} local only")
     if device_only:
         parts.append(f"{device_only} device only")
+    if romfs:
+        parts.append(f"{romfs} romfs")
     print(dim(f"\n{', '.join(parts)}"), file=sys.stderr)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,5 +1,6 @@
 """Tests for brasa.core.diff — file comparison logic and diff command."""
 
+import subprocess
 from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -21,16 +22,18 @@ DEVICE_LS_OUTPUT = """\
 """
 
 
-def _setup_local(tmp_path: Path, files: dict[str, str]) -> DeployConfig:
+def _setup_local(
+    tmp_path: Path, files: dict[str, str], **kwargs: object
+) -> DeployConfig:
     """Create local files in tmp_path/src and return a DeployConfig pointing there."""
     src_dir = tmp_path / "src"
     src_dir.mkdir(exist_ok=True)
     for name, content in files.items():
         (src_dir / name).write_text(content)
-    return DeployConfig(src=str(src_dir))
+    return DeployConfig(src=str(src_dir), **kwargs)  # type: ignore[arg-type]
 
 
-# ── diff_files ─────────────────────────────────────────────────────────────
+# ── diff_files (flat / romfs=False) ──────────────────────────────────────────
 
 
 @patch("brasa.core.diff.fs_cat")
@@ -38,7 +41,9 @@ def _setup_local(tmp_path: Path, files: dict[str, str]) -> DeployConfig:
 def test_identical_files_no_diff(
     mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
 ) -> None:
-    cfg = _setup_local(tmp_path, {"boot.py": "# boot", "main.py": "# main"})
+    cfg = _setup_local(
+        tmp_path, {"boot.py": "# boot", "main.py": "# main"}, romfs=False
+    )
     mock_cat.side_effect = lambda _port, path: {
         "/boot.py": "# boot",
         "/main.py": "# main",
@@ -57,6 +62,7 @@ def test_modified_file(mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path) 
     cfg = _setup_local(
         tmp_path,
         {"boot.py": "# local boot\n", "main.py": "# main", "helper.py": "# helper"},
+        romfs=False,
     )
     mock_cat.side_effect = lambda _port, path: {
         "/boot.py": "# device boot\n",
@@ -76,7 +82,9 @@ def test_modified_file(mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path) 
 def test_local_only_file(
     mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
 ) -> None:
-    cfg = _setup_local(tmp_path, {"boot.py": "# boot", "extra.py": "# extra"})
+    cfg = _setup_local(
+        tmp_path, {"boot.py": "# boot", "extra.py": "# extra"}, romfs=False
+    )
     mock_cat.return_value = "# boot"
 
     diffs = diff_files("/dev/test", cfg)
@@ -90,7 +98,7 @@ def test_local_only_file(
 def test_device_only_file(
     mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
 ) -> None:
-    cfg = _setup_local(tmp_path, {"boot.py": "# boot"})
+    cfg = _setup_local(tmp_path, {"boot.py": "# boot"}, romfs=False)
     mock_cat.return_value = "# boot"
 
     diffs = diff_files("/dev/test", cfg)
@@ -102,11 +110,227 @@ def test_device_only_file(
 @patch("brasa.core.diff.fs_cat")
 @patch("brasa.core.diff.fs_ls", return_value="       10 .env\n       20 boot.py\n")
 def test_env_excluded(mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path) -> None:
-    cfg = _setup_local(tmp_path, {"boot.py": "# boot", ".env": "SECRET=1"})
+    cfg = _setup_local(tmp_path, {"boot.py": "# boot", ".env": "SECRET=1"}, romfs=False)
     mock_cat.return_value = "# boot"
 
     diffs = diff_files("/dev/test", cfg)
     assert all(d.path != ".env" for d in diffs)
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls", return_value=DEVICE_LS_OUTPUT)
+def test_romfs_false_unchanged(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    """romfs=False uses existing flat behavior."""
+    cfg = _setup_local(
+        tmp_path,
+        {"boot.py": "# boot", "main.py": "# main", "helper.py": "# helper"},
+        romfs=False,
+    )
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# boot",
+        "/main.py": "# main",
+        "/helper.py": "# helper",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    assert diffs == []
+
+
+# ── diff_files (ROMFS) ───────────────────────────────────────────────────────
+
+
+ROOT_LS_ROMFS = """\
+       123 boot.py
+       456 main.py
+        42 .env
+"""
+
+ROM_LS = """\
+       100 app.mpy
+       200 utils.mpy
+"""
+
+
+def _fs_ls_side_effect(root_output: str, rom_output: str | None = None):
+    """Return a side_effect function for fs_ls dispatching on path."""
+
+    def _side_effect(_port: str, path: str) -> str:
+        if path == "/":
+            return root_output
+        if path == "/rom/":
+            if rom_output is None:
+                raise subprocess.CalledProcessError(1, "mpremote")
+            return rom_output
+        return ""
+
+    return _side_effect
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls")
+def test_romfs_all_synced(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    """romfs=true, boot files match, .mpy files in /rom/ -> boot files no diff, other files ROMFS."""
+    cfg = _setup_local(
+        tmp_path,
+        {
+            "boot.py": "# boot",
+            "main.py": "# main",
+            "app.py": "# app",
+            "utils.py": "# utils",
+        },
+        romfs=True,
+        boot_files=("boot.py", "main.py"),
+    )
+    mock_ls.side_effect = _fs_ls_side_effect(ROOT_LS_ROMFS, ROM_LS)
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# boot",
+        "/main.py": "# main",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    romfs_diffs = [d for d in diffs if d.status == DiffStatus.ROMFS]
+    assert len(romfs_diffs) == 2
+    assert {d.path for d in romfs_diffs} == {"app.py", "utils.py"}
+    # No modified boot files.
+    assert not [d for d in diffs if d.status == DiffStatus.MODIFIED]
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls")
+def test_romfs_local_only(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    """romfs=true, local .py with no .mpy -> LOCAL_ONLY."""
+    cfg = _setup_local(
+        tmp_path,
+        {
+            "boot.py": "# boot",
+            "main.py": "# main",
+            "app.py": "# app",
+            "newfile.py": "# new",
+        },
+        romfs=True,
+        boot_files=("boot.py", "main.py"),
+    )
+    mock_ls.side_effect = _fs_ls_side_effect(ROOT_LS_ROMFS, "       100 app.mpy\n")
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# boot",
+        "/main.py": "# main",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    local_only = [d for d in diffs if d.status == DiffStatus.LOCAL_ONLY]
+    assert len(local_only) == 1
+    assert local_only[0].path == "newfile.py"
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls")
+def test_romfs_device_only(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    """romfs=true, .mpy with no local .py -> DEVICE_ONLY with .mpy name."""
+    cfg = _setup_local(
+        tmp_path,
+        {"boot.py": "# boot", "main.py": "# main", "app.py": "# app"},
+        romfs=True,
+        boot_files=("boot.py", "main.py"),
+    )
+    mock_ls.side_effect = _fs_ls_side_effect(
+        ROOT_LS_ROMFS, "       100 app.mpy\n       200 orphan.mpy\n"
+    )
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# boot",
+        "/main.py": "# main",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    device_only = [d for d in diffs if d.status == DiffStatus.DEVICE_ONLY]
+    assert len(device_only) == 1
+    assert device_only[0].path == "orphan.mpy"
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls")
+def test_romfs_boot_file_modified(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    """romfs=true, boot file content differs -> MODIFIED."""
+    cfg = _setup_local(
+        tmp_path,
+        {"boot.py": "# local boot\n", "main.py": "# main", "app.py": "# app"},
+        romfs=True,
+        boot_files=("boot.py", "main.py"),
+    )
+    mock_ls.side_effect = _fs_ls_side_effect(ROOT_LS_ROMFS, "       100 app.mpy\n")
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# device boot\n",
+        "/main.py": "# main",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    modified = [d for d in diffs if d.status == DiffStatus.MODIFIED]
+    assert len(modified) == 1
+    assert modified[0].path == "boot.py"
+    assert any("device:/boot.py" in line for line in modified[0].diff_lines)
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls")
+def test_romfs_no_rom_directory(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    """romfs=true, fs_ls('/rom/') raises CalledProcessError -> non-boot LOCAL_ONLY."""
+    cfg = _setup_local(
+        tmp_path,
+        {"boot.py": "# boot", "main.py": "# main", "app.py": "# app"},
+        romfs=True,
+        boot_files=("boot.py", "main.py"),
+    )
+    mock_ls.side_effect = _fs_ls_side_effect(ROOT_LS_ROMFS, None)
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# boot",
+        "/main.py": "# main",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    local_only = [d for d in diffs if d.status == DiffStatus.LOCAL_ONLY]
+    assert len(local_only) == 1
+    assert local_only[0].path == "app.py"
+
+
+@patch("brasa.core.diff.fs_cat")
+@patch("brasa.core.diff.fs_ls")
+def test_romfs_stale_root_py_files(
+    mock_ls: MagicMock, mock_cat: MagicMock, tmp_path: Path
+) -> None:
+    """romfs=true, stale .py at root that aren't boot files -> DEVICE_ONLY."""
+    root_with_stale = """\
+       123 boot.py
+       456 main.py
+       789 old_app.py
+        42 .env
+"""
+    cfg = _setup_local(
+        tmp_path,
+        {"boot.py": "# boot", "main.py": "# main", "app.py": "# app"},
+        romfs=True,
+        boot_files=("boot.py", "main.py"),
+    )
+    mock_ls.side_effect = _fs_ls_side_effect(root_with_stale, "       100 app.mpy\n")
+    mock_cat.side_effect = lambda _port, path: {
+        "/boot.py": "# boot",
+        "/main.py": "# main",
+    }[path]
+
+    diffs = diff_files("/dev/test", cfg)
+    device_only = [d for d in diffs if d.status == DiffStatus.DEVICE_ONLY]
+    assert len(device_only) == 1
+    assert device_only[0].path == "old_app.py"
 
 
 # ── print_diff ─────────────────────────────────────────────────────────────
@@ -150,6 +374,21 @@ def test_print_diff_with_local_and_device_only(
     assert "Only on device: old.py" in captured.err
     assert "1 local only" in captured.err
     assert "1 device only" in captured.err
+
+
+def test_print_diff_with_romfs(capsys: pytest.CaptureFixture[str]) -> None:
+    """print_diff with ROMFS entries shows 'Deployed (romfs)' and 'romfs' in summary."""
+    diffs = [
+        FileDiff(path="app.py", status=DiffStatus.ROMFS, diff_lines=[]),
+        FileDiff(path="utils.py", status=DiffStatus.ROMFS, diff_lines=[]),
+        FileDiff(path="new.py", status=DiffStatus.LOCAL_ONLY, diff_lines=[]),
+    ]
+    print_diff(diffs)
+    captured = capsys.readouterr()
+    assert "Deployed (romfs): app.py" in captured.err
+    assert "Deployed (romfs): utils.py" in captured.err
+    assert "2 romfs" in captured.err
+    assert "1 local only" in captured.err
 
 
 # ── diff command wiring ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When `romfs=true`, `brasa diff` now scans `/rom/` for `.mpy` files and matches them against local `.py` sources, reporting synced files as "Deployed (romfs)"
- Boot files are still text-diffed against the device root; stale `.py` files at root (leftover from flat deploys) are flagged as device-only
- Moved `_excluded_filenames` helper from `deploy.py` into `DeployConfig.excluded_filenames` property for reuse across modules
- Added `ROMFS` status to `DiffStatus` enum and updated `print_diff` summary output

Fixes #56

## Test plan

- [x] 7 new unit tests covering ROMFS diff scenarios (all synced, local-only, device-only, modified boot file, missing /rom/ directory, stale root files, print output)
- [x] Existing flat-mode diff tests updated and passing
- [x] Deploy tests passing (uses new `cfg.excluded_filenames` property)
- [x] Full suite: 114 tests passing
- [x] `ruff check`, `ruff format`, `ty check` all clean

## Verification (manual, requires device)
1. Connect a MicroPython device
2. `cd` to a project with `romfs = true` (e.g., neo-redstone)
3. `brasa deploy` to push files
4. `brasa diff` — should show boot files as diffable, other files as "Deployed (romfs)", summary should be accurate
5. Modify a boot file locally → `brasa diff` should show it as modified with unified diff
6. Add a new .py file locally → `brasa diff` should show it as "Only local"