### PR TITLE
refactor: migrate commands to standalone Typer sub-apps

### DIFF
--- a/src/brasa/cli.py
+++ b/src/brasa/cli.py
@@ -1,17 +1,25 @@
+"""brasa CLI — MicroPython developer tools."""
+
 from importlib.metadata import version
 
 import typer
+
+from brasa.commands.deploy import app as deploy_app
+from brasa.commands.detect import app as detect_app
+from brasa.commands.dev import app as dev_app
+from brasa.commands.diff import app as diff_app
+from brasa.commands.exec import app as exec_app
+from brasa.commands.firmware import firmware_app
+from brasa.commands.flash import app as flash_app
+from brasa.commands.repl import app as repl_app
+from brasa.commands.restart import app as restart_app
+from brasa.commands.serial import app as serial_app
 
 app = typer.Typer(
     name="brasa",
     help="MicroPython developer tools — flash, deploy, watch, monitor.",
     no_args_is_help=True,
 )
-
-
-def port_override(ctx: typer.Context) -> str | None:
-    """Extract the ``--port`` override from the CLI context."""
-    return ctx.obj.get("port") if ctx.obj else None
 
 
 def _version_callback(value: bool) -> None:
@@ -34,35 +42,16 @@ def _main(
     ctx.obj["port"] = port
 
 
-# Register commands — imported after `app` is defined to avoid circular imports.
-from brasa.commands import (  # noqa: E402, F811
-    deploy,
-    detect,
-    dev,
-    diff,
-    exec,
-    flash,
-    repl,
-    restart,
-    serial,
-)
-from brasa.commands.firmware import firmware_app  # noqa: E402
-
+app.add_typer(deploy_app)
+app.add_typer(detect_app)
+app.add_typer(dev_app)
+app.add_typer(diff_app)
+app.add_typer(exec_app)
+app.add_typer(flash_app)
+app.add_typer(repl_app)
+app.add_typer(restart_app)
+app.add_typer(serial_app)
 app.add_typer(firmware_app, name="firmware")
-
-# Keep references so linters don't flag unused imports.
-__all__ = [
-    "deploy",
-    "detect",
-    "dev",
-    "diff",
-    "exec",
-    "firmware_app",
-    "flash",
-    "repl",
-    "restart",
-    "serial",
-]
 
 
 def main() -> None:

--- a/src/brasa/commands/deploy.py
+++ b/src/brasa/commands/deploy.py
@@ -2,7 +2,6 @@
 
 import typer
 
-from brasa.cli import app, port_override
 from brasa.core.config import require_config
 from brasa.core.deploy import deploy as deploy_to_device
 from brasa.core.device import dtr_reset
@@ -10,12 +9,14 @@ from brasa.core.lock import port_lock
 from brasa.core.output import success
 from brasa.core.port import resolve_port
 
+app = typer.Typer()
+
 
 @app.command()
 def deploy(ctx: typer.Context) -> None:
     """Compile and push project files to the device."""
     cfg = require_config()
-    port = resolve_port(port_override(ctx))
+    port = resolve_port(ctx.obj.get("port"))
     with port_lock(port, "deploy"):
         deploy_to_device(port, cfg.deploy)
         dtr_reset(port)

--- a/src/brasa/commands/detect.py
+++ b/src/brasa/commands/detect.py
@@ -2,12 +2,13 @@
 
 import typer
 
-from brasa.cli import app, port_override
 from brasa.core.output import print_stdout
 from brasa.core.port import resolve_port
+
+app = typer.Typer()
 
 
 @app.command()
 def detect(ctx: typer.Context) -> None:
     """Detect the serial port of a connected MicroPython device."""
-    print_stdout(resolve_port(port_override(ctx)))
+    print_stdout(resolve_port(ctx.obj.get("port")))

--- a/src/brasa/commands/dev.py
+++ b/src/brasa/commands/dev.py
@@ -9,7 +9,6 @@ import time
 import typer
 import watchfiles
 
-from brasa.cli import app, port_override
 from brasa.core.config import BrasaConfig, require_config
 from brasa.core.deploy import deploy
 from brasa.core.device import dtr_reset
@@ -17,6 +16,8 @@ from brasa.core.lock import port_lock
 from brasa.core.output import error, status, success, warn
 from brasa.core.port import resolve_port
 from brasa.core.serial import SerialReader
+
+app = typer.Typer()
 
 _SERIAL_RELEASE_DELAY = 1.2  # seconds for serial port to release before redeploy
 _DEPLOY_RETRY_DELAY = 10  # seconds between failed deploy retries
@@ -27,7 +28,7 @@ _RESET_SETTLE_DELAY = 1  # seconds after device reset before resuming serial
 def dev(ctx: typer.Context) -> None:
     """Deploy, watch for changes, and stream serial output."""
     cfg = require_config()
-    port = resolve_port(port_override(ctx), cfg.port.patterns)
+    port = resolve_port(ctx.obj.get("port"), cfg.port.patterns)
 
     with port_lock(port, "dev"):
         os.environ["BRASA_PORT_LOCKED"] = port

--- a/src/brasa/commands/diff.py
+++ b/src/brasa/commands/diff.py
@@ -2,18 +2,19 @@
 
 import typer
 
-from brasa.cli import app, port_override
 from brasa.core.config import require_config
 from brasa.core.diff import diff_files, print_diff
 from brasa.core.lock import port_lock
 from brasa.core.port import resolve_port
+
+app = typer.Typer()
 
 
 @app.command()
 def diff(ctx: typer.Context) -> None:
     """Show differences between local src/ and device files."""
     cfg = require_config()
-    port = resolve_port(port_override(ctx))
+    port = resolve_port(ctx.obj.get("port"))
     with port_lock(port, "diff"):
         diffs = diff_files(port, cfg.deploy)
         print_diff(diffs)

--- a/src/brasa/commands/exec.py
+++ b/src/brasa/commands/exec.py
@@ -2,11 +2,12 @@
 
 import typer
 
-from brasa.cli import app, port_override
 from brasa.core.device import exec_expr
 from brasa.core.lock import port_lock
 from brasa.core.output import print_stdout
 from brasa.core.port import resolve_port
+
+app = typer.Typer()
 
 
 @app.command(name="exec")
@@ -15,7 +16,7 @@ def exec_cmd(
     expression: str = typer.Argument(help="Python expression to execute on device"),
 ) -> None:
     """Execute a Python expression on the device."""
-    port = resolve_port(port_override(ctx))
+    port = resolve_port(ctx.obj.get("port"))
     with port_lock(port, "exec"):
         result = exec_expr(port, expression)
         if result:

--- a/src/brasa/commands/firmware.py
+++ b/src/brasa/commands/firmware.py
@@ -229,7 +229,7 @@ def install(
     ),
 ) -> None:
     """Download and install firmware onto the device, then save to config."""
-    port_flag = ctx.obj.get("port") if ctx.obj else None
+    port_flag = ctx.obj.get("port")
     entry = _resolve_entry(
         board, variant, version, from_config=from_config, port=port_flag
     )
@@ -267,7 +267,7 @@ def show(
     """Show the firmware version running on the connected device."""
     import json as json_mod
 
-    port_flag = ctx.obj.get("port") if ctx.obj else None
+    port_flag = ctx.obj.get("port")
     port = resolve_port(port_flag)
     with port_lock(port, "firmware show"):
         info = device_firmware_info(port)

--- a/src/brasa/commands/flash.py
+++ b/src/brasa/commands/flash.py
@@ -2,13 +2,14 @@
 
 import typer
 
-from brasa.cli import app, port_override
 from brasa.core import output
 from brasa.core.config import require_config
 from brasa.core.firmware import download_firmware, flash_firmware
 from brasa.core.lock import port_lock
 from brasa.core.output import success
 from brasa.core.port import resolve_port
+
+app = typer.Typer()
 
 
 @app.command(deprecated=True)
@@ -26,7 +27,7 @@ def flash(ctx: typer.Context) -> None:
         output.error("firmware.date is required in config")
         raise SystemExit(1)
 
-    port = resolve_port(port_override(ctx))
+    port = resolve_port(ctx.obj.get("port"))
     firmware_path = download_firmware(cfg.firmware)
     with port_lock(port, "flash"):
         flash_firmware(port, firmware_path)

--- a/src/brasa/commands/repl.py
+++ b/src/brasa/commands/repl.py
@@ -2,15 +2,16 @@
 
 import typer
 
-from brasa.cli import app, port_override
 from brasa.core.device import repl as device_repl
 from brasa.core.lock import port_lock
 from brasa.core.port import resolve_port
+
+app = typer.Typer()
 
 
 @app.command()
 def repl(ctx: typer.Context) -> None:
     """Open an interactive REPL on the device."""
-    port = resolve_port(port_override(ctx))
+    port = resolve_port(ctx.obj.get("port"))
     with port_lock(port, "repl"):
         device_repl(port)

--- a/src/brasa/commands/restart.py
+++ b/src/brasa/commands/restart.py
@@ -2,17 +2,18 @@
 
 import typer
 
-from brasa.cli import app, port_override
 from brasa.core.device import reset
 from brasa.core.lock import port_lock
 from brasa.core.output import success
 from brasa.core.port import resolve_port
 
+app = typer.Typer()
+
 
 @app.command()
 def restart(ctx: typer.Context) -> None:
     """Reboot the MicroPython device."""
-    port = resolve_port(port_override(ctx))
+    port = resolve_port(ctx.obj.get("port"))
     with port_lock(port, "restart"):
         reset(port)
         success("device restarted")

--- a/src/brasa/commands/serial.py
+++ b/src/brasa/commands/serial.py
@@ -2,10 +2,11 @@
 
 import typer
 
-from brasa.cli import app, port_override
 from brasa.core.lock import port_lock
 from brasa.core.port import resolve_port
 from brasa.core.serial import SerialReader
+
+app = typer.Typer()
 
 
 @app.command()
@@ -14,7 +15,7 @@ def serial(
     baud: int = typer.Option(115200, "--baud", "-b", help="Baud rate"),
 ) -> None:
     """Monitor serial output from a MicroPython device."""
-    port = resolve_port(port_override(ctx))
+    port = resolve_port(ctx.obj.get("port"))
     with port_lock(port, "serial"):
         reader = SerialReader(port, baud=baud)
         reader.run_blocking()


### PR DESCRIPTION
## Summary
- Each command module now creates its own `typer.Typer()` instance instead of importing `app` from `cli.py`
- `cli.py` registers all sub-apps via `app.add_typer()`, eliminating the circular import workaround (deferred imports with `# noqa: E402`)
- Removes `port_override()` helper — commands access `ctx.obj.get("port")` directly

## Test plan
- [x] All 191 tests pass
- [x] `brasa --help` shows all commands at top level
- [x] `ruff check` clean
- [x] `ty check` clean

Closes #61