### PR TITLE
refactor: clean up firmware_index.py — unify parsers and cache pattern

### DIFF
--- a/src/brasa/core/firmware_index.py
+++ b/src/brasa/core/firmware_index.py
@@ -211,7 +211,8 @@ def fetch_board_index(board: str, *, force_refresh: bool = False) -> BoardIndex:
         label=f"index for {board}",
         force_refresh=force_refresh,
     )
-    return BoardIndex(board=board, entries=tuple(entries), fetched_at=time.time())
+    fetched_at = path.stat().st_mtime if path.exists() else time.time()
+    return BoardIndex(board=board, entries=tuple(entries), fetched_at=fetched_at)
 
 
 def list_variants(index: BoardIndex) -> list[str]:

--- a/src/brasa/core/firmware_index.py
+++ b/src/brasa/core/firmware_index.py
@@ -6,14 +6,18 @@ import json
 import os
 import re
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from html.parser import HTMLParser
 from pathlib import Path
+from typing import TypeVar
 
 import httpx
 
 from brasa.core import output
 from brasa.core.firmware_resolver import firmware_ext, firmware_filename
+
+_T = TypeVar("_T")
 
 _BASE_URL = "https://micropython.org"
 _INDEX_TTL = 3600  # 1 hour
@@ -68,21 +72,6 @@ class BoardIndex:
     board: str
     entries: tuple[FirmwareEntry, ...]
     fetched_at: float
-
-
-class _FirmwareLinkParser(HTMLParser):
-    """Extract firmware download hrefs from a micropython.org board page."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.hrefs: list[str] = []
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if tag != "a":
-            return
-        for name, value in attrs:
-            if name == "href" and value and "/resources/firmware/" in value:
-                self.hrefs.append(value)
 
 
 def cache_dir() -> Path:
@@ -151,12 +140,11 @@ def _scrape_board_page(board: str) -> list[FirmwareEntry]:
         output.error(f"failed to fetch firmware index: HTTP {exc.response.status_code}")
         raise SystemExit(1)
 
-    parser = _FirmwareLinkParser()
-    parser.feed(response.text)
+    hrefs = re.findall(r'href="([^"]*?/resources/firmware/[^"]*)"', response.text)
 
     entries: list[FirmwareEntry] = []
     seen: set[str] = set()
-    for href in parser.hrefs:
+    for href in hrefs:
         entry = _parse_firmware_href(href, board)
         if entry and entry.filename not in seen:
             seen.add(entry.filename)
@@ -164,11 +152,36 @@ def _scrape_board_page(board: str) -> list[FirmwareEntry]:
     return entries
 
 
-def _save_index(board: str, entries: list[FirmwareEntry]) -> BoardIndex:
+def _cached_fetch(
+    path: Path,
+    scrape_fn: Callable[[], _T],
+    load_fn: Callable[[Path], _T],
+    save_fn: Callable[[Path, _T], None],
+    label: str,
+    *,
+    force_refresh: bool = False,
+) -> _T:
+    """Generic cache-or-scrape helper used by board index and board list fetchers."""
+    if not force_refresh and _is_fresh(path):
+        output.status("firmware", f"using cached {label}")
+        try:
+            return load_fn(path)
+        except (json.JSONDecodeError, KeyError):
+            output.warn(f"corrupted cache for {label}, re-fetching")
+            path.unlink(missing_ok=True)
+
+    data = scrape_fn()
+    if not data:
+        output.warn(f"scrape returned no results for {label} — skipping cache write")
+        return data
+    save_fn(path, data)
+    return data
+
+
+def _save_board_index(path: Path, entries: list[FirmwareEntry]) -> None:
     """Save a board index to the JSON cache."""
+    board = entries[0].board
     now = time.time()
-    index = BoardIndex(board=board, entries=tuple(entries), fetched_at=now)
-    path = _index_path(board)
     path.parent.mkdir(parents=True, exist_ok=True)
     data = {
         "board": board,
@@ -179,33 +192,26 @@ def _save_index(board: str, entries: list[FirmwareEntry]) -> BoardIndex:
         path.write_text(json.dumps(data, indent=2))
     except OSError as exc:
         output.warn(f"could not cache firmware index: {exc}")
-    return index
 
 
-def _load_index(board: str) -> BoardIndex:
-    """Load a board index from the JSON cache."""
-    path = _index_path(board)
-    try:
-        data = json.loads(path.read_text())
-    except json.JSONDecodeError:
-        output.warn(f"corrupted cache for {board}, re-fetching")
-        path.unlink(missing_ok=True)
-        entries = _scrape_board_page(board)
-        return _save_index(board, entries)
-    entries = tuple(FirmwareEntry(**e) for e in data["entries"])
-    return BoardIndex(
-        board=data["board"], entries=entries, fetched_at=data["fetched_at"]
-    )
+def _load_board_index(path: Path) -> list[FirmwareEntry]:
+    """Load a board index from the JSON cache and return the entry list."""
+    data = json.loads(path.read_text())
+    return [FirmwareEntry(**e) for e in data["entries"]]
 
 
 def fetch_board_index(board: str, *, force_refresh: bool = False) -> BoardIndex:
     """Return firmware entries for a board, using cache when fresh."""
     path = _index_path(board)
-    if not force_refresh and _is_fresh(path):
-        output.status("firmware", f"using cached index for {board}")
-        return _load_index(board)
-    entries = _scrape_board_page(board)
-    return _save_index(board, entries)
+    entries = _cached_fetch(
+        path,
+        scrape_fn=lambda: _scrape_board_page(board),
+        load_fn=_load_board_index,
+        save_fn=_save_board_index,
+        label=f"index for {board}",
+        force_refresh=force_refresh,
+    )
+    return BoardIndex(board=board, entries=tuple(entries), fetched_at=time.time())
 
 
 def list_variants(index: BoardIndex) -> list[str]:
@@ -331,20 +337,14 @@ def _scrape_board_list() -> list[BoardInfo]:
     return boards
 
 
-def fetch_board_list(*, force_refresh: bool = False) -> list[BoardInfo]:
-    """Return all available boards, using cache when fresh."""
-    path = _board_list_path()
-    if not force_refresh and _is_fresh(path):
-        output.status("firmware", "using cached board list")
-        try:
-            data = json.loads(path.read_text())
-        except json.JSONDecodeError:
-            output.warn("corrupted board list cache, re-fetching")
-            path.unlink(missing_ok=True)
-        else:
-            return [BoardInfo(**b) for b in data["boards"]]
+def _load_board_list(path: Path) -> list[BoardInfo]:
+    """Load board list from the JSON cache."""
+    data = json.loads(path.read_text())
+    return [BoardInfo(**b) for b in data["boards"]]
 
-    boards = _scrape_board_list()
+
+def _save_board_list(path: Path, boards: list[BoardInfo]) -> None:
+    """Save board list to the JSON cache."""
     path.parent.mkdir(parents=True, exist_ok=True)
     data = {
         "fetched_at": time.time(),
@@ -354,4 +354,16 @@ def fetch_board_list(*, force_refresh: bool = False) -> list[BoardInfo]:
         path.write_text(json.dumps(data, indent=2))
     except OSError as exc:
         output.warn(f"could not cache board list: {exc}")
-    return boards
+
+
+def fetch_board_list(*, force_refresh: bool = False) -> list[BoardInfo]:
+    """Return all available boards, using cache when fresh."""
+    path = _board_list_path()
+    return _cached_fetch(
+        path,
+        scrape_fn=_scrape_board_list,
+        load_fn=_load_board_list,
+        save_fn=_save_board_list,
+        label="board list",
+        force_refresh=force_refresh,
+    )

--- a/tests/test_firmware_index.py
+++ b/tests/test_firmware_index.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import time
 from dataclasses import asdict
 from pathlib import Path
@@ -14,7 +15,6 @@ from brasa.core.firmware_index import (
     BoardInfo,
     FirmwareEntry,
     _BoardLinkParser,
-    _FirmwareLinkParser,
     _is_fresh,
     _parse_firmware_href,
     cache_dir,
@@ -42,16 +42,15 @@ _SAMPLE_HTML = """
 """
 
 
-def test_parser_extracts_firmware_hrefs() -> None:
-    parser = _FirmwareLinkParser()
-    parser.feed(_SAMPLE_HTML)
-    assert len(parser.hrefs) == 6  # 4 .bin + 1 .elf + 1 .map
+def test_regex_extracts_firmware_hrefs() -> None:
+    hrefs = re.findall(r'href="([^"]*?/resources/firmware/[^"]*)"', _SAMPLE_HTML)
+    assert len(hrefs) == 6  # 4 .bin + 1 .elf + 1 .map
 
 
-def test_parser_ignores_non_firmware_links() -> None:
-    parser = _FirmwareLinkParser()
-    parser.feed('<a href="https://github.com">GH</a><a href="/download/">dl</a>')
-    assert parser.hrefs == []
+def test_regex_ignores_non_firmware_links() -> None:
+    html = '<a href="https://github.com">GH</a><a href="/download/">dl</a>'
+    hrefs = re.findall(r'href="([^"]*?/resources/firmware/[^"]*)"', html)
+    assert hrefs == []
 
 
 # ── _parse_firmware_href ────────────────────────────────────────────────────
@@ -366,3 +365,34 @@ def test_corrupted_board_list_cache_triggers_rescrape(
     mock_scrape.assert_called_once()
     assert len(result) == 2
     assert result[0].id == "ESP32_GENERIC"
+
+
+# ── Empty-result guard ─────────────────────────────────────────────────────
+
+
+@patch("brasa.core.firmware_index._scrape_board_page", return_value=[])
+def test_empty_scrape_skips_cache_write(
+    mock_scrape: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("BRASA_CACHE_DIR", str(tmp_path))
+    cache_file = tmp_path / "ESP32_GENERIC.index.json"
+
+    result = fetch_board_index("ESP32_GENERIC")
+
+    mock_scrape.assert_called_once()
+    assert len(result.entries) == 0
+    assert not cache_file.exists()
+
+
+@patch("brasa.core.firmware_index._scrape_board_list", return_value=[])
+def test_empty_board_list_scrape_skips_cache_write(
+    mock_scrape: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("BRASA_CACHE_DIR", str(tmp_path))
+    cache_file = tmp_path / "boards.json"
+
+    result = fetch_board_list()
+
+    mock_scrape.assert_called_once()
+    assert result == []
+    assert not cache_file.exists()


### PR DESCRIPTION
## Summary
- Replaced `_FirmwareLinkParser` HTMLParser subclass with a single `re.findall` call — the class was stateless and trivially simple
- Extracted `_cached_fetch()` generic helper to deduplicate the cache-or-scrape pattern shared by `fetch_board_index` and `fetch_board_list`
- Added empty-result guard: when scrape returns no results, skip the cache write to avoid caching failures for the full TTL
- Renamed `_load_index`/`_save_index` to `_load_board_index`/`_save_board_index` with `path` parameter for consistency
- Extracted `_load_board_list`/`_save_board_list` from inline logic in `fetch_board_list`

Net result: ~360 lines down to ~370 lines (slight increase from extracted helpers), but duplicated cache logic is now unified in one place.

## Test plan
- [x] Updated regex extraction tests replace deleted HTMLParser tests
- [x] Added empty-result guard tests for both board index and board list
- [x] All 211 existing tests pass
- [x] ruff format, ruff check, ty check all clean

Closes #66